### PR TITLE
Fix a small todo

### DIFF
--- a/src/components/dashboard/MemoryVisualizer.tsx
+++ b/src/components/dashboard/MemoryVisualizer.tsx
@@ -58,8 +58,8 @@ export function MemoryVisualizer() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedType, setSelectedType] = useState<string>('all');
   const [isLoading, setIsLoading] = useState(false);
-  const [customApiKey, setCustomApiKey] = useState('vx_vxz9i6hcdpnubdbzf3pl559kqg2eatfo');
-  const [useCustomApiKey, setUseCustomApiKey] = useState(true);
+  const [customApiKey, setCustomApiKey] = useState('');
+  const [useCustomApiKey, setUseCustomApiKey] = useState(false);
   const [stats, setStats] = useState({
     totalMemories: 0,
     totalTags: 0,


### PR DESCRIPTION
Removed the hardcoded API key from the MemoryVisualizer component's initial state. This fixes a security vulnerability where an API key was exposed in the source code.

Changes:
- Set customApiKey initial state to empty string
- Set useCustomApiKey default to false (requires explicit user action)
- Users must now enter their own API key to use the custom API key feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key authentication is now disabled by default. Users must explicitly enable and provide their own API key to use custom authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->