### PR TITLE
improve dashboard UX: fix collapsed state wiring, mobile a11y, page titles

### DIFF
--- a/src/components/dashboard/ApiKeyManager.tsx
+++ b/src/components/dashboard/ApiKeyManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -116,6 +116,7 @@ export const ApiKeyManager = () => {
   const [isLoadingKeys, setIsLoadingKeys] = useState(false);
 
   // Activity dialog state
+  const activityRequestRef = useRef<string | null>(null);
   const [activityKeyId, setActivityKeyId] = useState<string | null>(null);
   const [activityKeyName, setActivityKeyName] = useState<string>('');
   const [activityRecords, setActivityRecords] = useState<ActivityRecord[]>([]);
@@ -485,7 +486,9 @@ export const ApiKeyManager = () => {
   };
 
   const fetchKeyActivity = async (keyId: string) => {
+    activityRequestRef.current = keyId;
     setIsLoadingActivity(true);
+    setActivityRecords([]);
     try {
       const { data, error } = await supabase
         .from('key_usage_analytics')
@@ -494,14 +497,20 @@ export const ApiKeyManager = () => {
         .order('timestamp', { ascending: false })
         .limit(50);
       if (error) throw error;
-      setActivityRecords((data as ActivityRecord[]) ?? []);
+      if (activityRequestRef.current === keyId) {
+        setActivityRecords((data as ActivityRecord[]) ?? []);
+      }
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to load activity';
-      console.error('ApiKeyManager: fetchKeyActivity error:', error);
-      toast({ title: 'Error', description: errorMessage, variant: 'destructive' });
-      setActivityRecords([]);
+      if (activityRequestRef.current === keyId) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to load activity';
+        console.error('ApiKeyManager: fetchKeyActivity error:', error);
+        toast({ title: 'Error', description: errorMessage, variant: 'destructive' });
+        setActivityRecords([]);
+      }
     } finally {
-      setIsLoadingActivity(false);
+      if (activityRequestRef.current === keyId) {
+        setIsLoadingActivity(false);
+      }
     }
   };
 

--- a/src/components/dashboard/ApiKeyManager.tsx
+++ b/src/components/dashboard/ApiKeyManager.tsx
@@ -61,6 +61,13 @@ interface ServiceScope {
   max_calls_per_minute?: number;
   max_calls_per_day?: number;
 }
+
+interface ActivityRecord {
+  id: string;
+  operation: string;
+  success: boolean | null;
+  timestamp: string | null;
+}
 import { supabase } from "@/integrations/supabase/client";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
@@ -107,6 +114,12 @@ export const ApiKeyManager = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [isLoadingKeys, setIsLoadingKeys] = useState(false);
+
+  // Activity dialog state
+  const [activityKeyId, setActivityKeyId] = useState<string | null>(null);
+  const [activityKeyName, setActivityKeyName] = useState<string>('');
+  const [activityRecords, setActivityRecords] = useState<ActivityRecord[]>([]);
+  const [isLoadingActivity, setIsLoadingActivity] = useState(false);
 
   // Service scoping state
   const [serviceType, setServiceType] = useState<'all' | 'specific'>('all');
@@ -471,6 +484,27 @@ export const ApiKeyManager = () => {
     }
   };
 
+  const fetchKeyActivity = async (keyId: string) => {
+    setIsLoadingActivity(true);
+    try {
+      const { data, error } = await supabase
+        .from('key_usage_analytics')
+        .select('id, operation, success, timestamp')
+        .eq('key_id', keyId)
+        .order('timestamp', { ascending: false })
+        .limit(50);
+      if (error) throw error;
+      setActivityRecords((data as ActivityRecord[]) ?? []);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to load activity';
+      console.error('ApiKeyManager: fetchKeyActivity error:', error);
+      toast({ title: 'Error', description: errorMessage, variant: 'destructive' });
+      setActivityRecords([]);
+    } finally {
+      setIsLoadingActivity(false);
+    }
+  };
+
   const formatDate = (dateString: string | null) => {
     if (!dateString) return "Never";
 
@@ -784,7 +818,7 @@ export const ApiKeyManager = () => {
                     {apiKeys.length === 1 ? "key" : "keys"}
                   </div>
 
-                  <div className="space-y-3">
+                  <div className="space-y-3 max-h-[360px] overflow-y-auto pr-1">
                     {apiKeys.map((key) => (
                       <div
                         key={key.id}
@@ -844,6 +878,11 @@ export const ApiKeyManager = () => {
                             variant="outline"
                             size="sm"
                             className="h-7 text-xs"
+                            onClick={() => {
+                              setActivityKeyId(key.id);
+                              setActivityKeyName(key.name);
+                              fetchKeyActivity(key.id);
+                            }}
                           >
                             View Activity
                           </Button>
@@ -867,6 +906,50 @@ export const ApiKeyManager = () => {
             </DialogFooter>
           </TabsContent>
         </Tabs>
+      </DialogContent>
+    </Dialog>
+
+    {/* Activity Dialog */}
+    <Dialog open={activityKeyId !== null} onOpenChange={(open) => { if (!open) { setActivityKeyId(null); setActivityRecords([]); } }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Activity — {activityKeyName}</DialogTitle>
+          <DialogDescription>Last 50 operations for this key</DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          {isLoadingActivity ? (
+            <div className="flex justify-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+            </div>
+          ) : activityRecords.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground py-8">
+              No activity recorded for this key yet.
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+              {activityRecords.map((record) => (
+                <div key={record.id} className="flex items-center justify-between p-2 rounded-md border text-sm">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Badge variant={record.success === false ? 'destructive' : 'secondary'} className="text-[10px] px-1.5 py-0 shrink-0">
+                      {record.success === false ? 'Failed' : 'OK'}
+                    </Badge>
+                    <span className="font-mono text-xs truncate">{record.operation}</span>
+                  </div>
+                  <span className="text-xs text-muted-foreground shrink-0 ml-2">
+                    {record.timestamp ? new Date(record.timestamp).toLocaleString() : '—'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => { setActivityKeyId(null); setActivityRecords([]); }}>
+            Close
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dashboard/ApiKeyManager.tsx
+++ b/src/components/dashboard/ApiKeyManager.tsx
@@ -527,6 +527,7 @@ export const ApiKeyManager = () => {
   };
 
   return (
+    <>
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="outline">
@@ -961,5 +962,6 @@ export const ApiKeyManager = () => {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+    </>
   );
 };

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -127,13 +127,15 @@ interface DashboardSidebarProps {
   className?: string;
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
+  id?: string;
 }
 
 export function DashboardSidebar({
   onNavigate,
   className,
   collapsed = false,
-  onCollapsedChange
+  onCollapsedChange,
+  id,
 }: DashboardSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -275,6 +277,7 @@ export function DashboardSidebar({
   return (
     <TooltipProvider>
       <aside
+        id={id}
         className={cn(
           "min-h-full border-r border-border bg-card flex flex-col shadow-lg transition-all duration-300",
           collapsed ? "w-16" : "w-64",
@@ -460,6 +463,7 @@ export function DashboardSidebar({
                   ) : (
                     <button
                       onClick={() => toggleSection(section.id)}
+                      aria-expanded={isOpen}
                       className={cn(
                         "w-full flex items-center justify-between px-3 py-2 rounded-md text-sm font-medium transition-colors",
                         hasActiveItem
@@ -494,6 +498,7 @@ export function DashboardSidebar({
                           >
                             <button
                               onClick={() => handleNavigate(item.path, item.label)}
+                              aria-current={active ? "page" : undefined}
                               className={cn(
                                 "flex-1 flex items-center justify-between px-3 py-1.5 rounded-md text-sm transition-colors",
                                 active
@@ -524,6 +529,7 @@ export function DashboardSidebar({
                                 e.stopPropagation();
                                 toggleFavorite(item.path);
                               }}
+                              aria-label={isFavorite ? `Remove ${item.label} from favorites` : `Add ${item.label} to favorites`}
                               className={cn(
                                 "p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity",
                                 isFavorite

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -337,26 +337,26 @@ export function DashboardSidebar({
               <kbd className="absolute right-2 top-2 pointer-events-none hidden sm:inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
                 <Command className="h-3 w-3" />K
               </kbd>
-            </div>
-          )}
 
-          {/* Search Results Dropdown */}
-          {!collapsed && isSearchFocused && searchResults.length > 0 && (
-            <div className="mt-1 z-50 bg-popover border border-border rounded-md shadow-lg overflow-hidden">
-              {searchResults.map((item) => {
-                const ItemIcon = item.icon;
-                return (
-                  <button
-                    key={item.id}
-                    onClick={() => handleNavigate(item.path, item.label)}
-                    className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors"
-                  >
-                    <ItemIcon className="h-4 w-4 text-muted-foreground" />
-                    <span>{item.label}</span>
-                    <span className="text-xs text-muted-foreground ml-auto">{item.section}</span>
-                  </button>
-                );
-              })}
+              {/* Search Results Dropdown — absolutely anchored to the search bar */}
+              {isSearchFocused && searchResults.length > 0 && (
+                <div className="absolute left-0 right-0 top-full mt-1 z-50 bg-popover border border-border rounded-md shadow-lg overflow-hidden">
+                  {searchResults.map((item) => {
+                    const ItemIcon = item.icon;
+                    return (
+                      <button
+                        key={item.id}
+                        onClick={() => handleNavigate(item.path, item.label)}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50 transition-colors"
+                      >
+                        <ItemIcon className="h-4 w-4 text-muted-foreground" />
+                        <span>{item.label}</span>
+                        <span className="text-xs text-muted-foreground ml-auto">{item.section}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/layout/DashboardSidebar.tsx
+++ b/src/components/layout/DashboardSidebar.tsx
@@ -128,6 +128,7 @@ interface DashboardSidebarProps {
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   id?: string;
+  isInteractive?: boolean;
 }
 
 export function DashboardSidebar({
@@ -136,9 +137,11 @@ export function DashboardSidebar({
   collapsed = false,
   onCollapsedChange,
   id,
+  isInteractive = true,
 }: DashboardSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
+  const asideRef = React.useRef<HTMLElement | null>(null);
   const [openSections, setOpenSections] = React.useState<Set<string>>(() => {
     const initial = new Set<string>();
     NAV_SECTIONS.forEach(section => {
@@ -160,6 +163,18 @@ export function DashboardSidebar({
       }
     };
   }, []);
+
+  useEffect(() => {
+    const aside = asideRef.current;
+    if (!aside) return;
+
+    if (isInteractive) {
+      aside.removeAttribute('inert');
+      return;
+    }
+
+    aside.setAttribute('inert', '');
+  }, [isInteractive]);
 
   // Recent pages state
   const [recentPages, setRecentPages] = React.useState<RecentPage[]>(() => {
@@ -277,10 +292,13 @@ export function DashboardSidebar({
   return (
     <TooltipProvider>
       <aside
+        ref={asideRef}
         id={id}
+        aria-hidden={!isInteractive}
         className={cn(
           "min-h-full border-r border-border bg-card flex flex-col shadow-lg transition-all duration-300",
           collapsed ? "w-16" : "w-64",
+          !isInteractive && "pointer-events-none",
           className
         )}
       >

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -108,13 +108,19 @@ const Dashboard = () => {
     }
   }, [sidebarOpen]);
 
-  // Body scroll lock while mobile drawer is open
+  // Body scroll lock while mobile drawer is open; restored on resize past breakpoint
   useEffect(() => {
-    const isMobile = window.innerWidth < 1024;
-    if (!sidebarOpen || !isMobile) return;
+    if (!sidebarOpen || window.innerWidth >= 1024) return;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+    const handleResize = () => {
+      if (window.innerWidth >= 1024) {
+        document.body.style.overflow = previousOverflow;
+      }
+    };
+    window.addEventListener('resize', handleResize);
     return () => {
+      window.removeEventListener('resize', handleResize);
       document.body.style.overflow = previousOverflow;
     };
   }, [sidebarOpen]);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -37,10 +37,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
 
 const SIDEBAR_COLLAPSED_KEY = 'maas-sidebar-collapsed';
+const DESKTOP_BREAKPOINT = 1024;
 
 const PAGE_META: Record<string, { title: string; subtitle?: string }> = {
   'overview':          { title: 'Overview' },
@@ -63,11 +64,34 @@ const Dashboard = () => {
   const { signOut } = useSupabaseAuth();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const pageTitleRef = useRef<HTMLHeadingElement>(null);
+  const previousBodyOverflowRef = useRef<string | null>(null);
+  const [isDesktopViewport, setIsDesktopViewport] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return window.innerWidth >= DESKTOP_BREAKPOINT;
+  });
+
+  const syncBodyScrollLock = useCallback((shouldLock: boolean) => {
+    if (typeof document === "undefined") return;
+
+    if (shouldLock) {
+      if (previousBodyOverflowRef.current === null) {
+        previousBodyOverflowRef.current = document.body.style.overflow;
+      }
+      document.body.style.overflow = "hidden";
+      return;
+    }
+
+    if (previousBodyOverflowRef.current !== null) {
+      document.body.style.overflow = previousBodyOverflowRef.current;
+      previousBodyOverflowRef.current = null;
+    }
+  }, []);
 
   // Close mobile drawer and return focus to the toggle button
-  const closeSidebar = () => {
+  const closeSidebar = (focusTarget?: HTMLElement | null) => {
     setSidebarOpen(false);
-    requestAnimationFrame(() => toggleButtonRef.current?.focus());
+    requestAnimationFrame(() => (focusTarget ?? toggleButtonRef.current)?.focus());
   };
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
@@ -89,41 +113,35 @@ const Dashboard = () => {
   // Escape key closes mobile drawer
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && sidebarOpen && window.innerWidth < 1024) {
+      if (e.key === 'Escape' && sidebarOpen && !isDesktopViewport) {
         closeSidebar();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [sidebarOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isDesktopViewport, sidebarOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Move focus into sidebar when drawer opens on mobile
   useEffect(() => {
-    if (sidebarOpen && window.innerWidth < 1024) {
+    if (sidebarOpen && !isDesktopViewport) {
       const sidebar = document.getElementById('dashboard-sidebar');
       const firstFocusable = sidebar?.querySelector<HTMLElement>(
         'button, [href], input, [tabindex]:not([tabindex="-1"])'
       );
       firstFocusable?.focus();
     }
-  }, [sidebarOpen]);
+  }, [isDesktopViewport, sidebarOpen]);
 
   // Body scroll lock while mobile drawer is open; restored on resize past breakpoint
   useEffect(() => {
-    if (!sidebarOpen || window.innerWidth >= 1024) return;
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    const handleResize = () => {
-      if (window.innerWidth >= 1024) {
-        document.body.style.overflow = previousOverflow;
-      }
-    };
-    window.addEventListener('resize', handleResize);
+    const shouldLock = sidebarOpen && !isDesktopViewport;
+    syncBodyScrollLock(shouldLock);
+    if (!shouldLock) return;
+
     return () => {
-      window.removeEventListener('resize', handleResize);
-      document.body.style.overflow = previousOverflow;
+      syncBodyScrollLock(false);
     };
-  }, [sidebarOpen]);
+  }, [isDesktopViewport, sidebarOpen, syncBodyScrollLock]);
 
   // Determine active page based on route
   const getActivePage = () => {
@@ -148,6 +166,25 @@ const Dashboard = () => {
 
   const activePage = getActivePage();
   const pageMeta = PAGE_META[activePage] ?? { title: 'Dashboard' };
+
+  useEffect(() => {
+    document.title = `${pageMeta.title} | MaaS Dashboard`;
+  }, [pageMeta.title]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const desktop = window.innerWidth >= DESKTOP_BREAKPOINT;
+      setIsDesktopViewport(desktop);
+      syncBodyScrollLock(sidebarOpen && !desktop);
+      if (desktop) {
+        setSidebarOpen(true);
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [sidebarOpen, syncBodyScrollLock]);
 
   // Render the active page content
   const renderContent = () => {
@@ -248,6 +285,7 @@ const Dashboard = () => {
         {/* Sidebar */}
         <DashboardSidebar
           id="dashboard-sidebar"
+          isInteractive={isDesktopViewport || sidebarOpen}
           className={cn(
             "fixed lg:static left-0 top-16 bottom-0 z-40 transform transition-transform duration-200 ease-in-out lg:transform-none",
             "lg:h-auto",
@@ -257,14 +295,14 @@ const Dashboard = () => {
           onCollapsedChange={handleCollapsedChange}
           onNavigate={() => {
             // Close sidebar on mobile after navigation
-            if (window.innerWidth < 1024) {
-              setSidebarOpen(false);
+            if (!isDesktopViewport) {
+              closeSidebar(pageTitleRef.current);
             }
           }}
         />
 
         {/* Mobile Overlay */}
-        {sidebarOpen && (
+        {!isDesktopViewport && sidebarOpen && (
           <div
             className="fixed inset-0 bg-black/50 z-30 lg:hidden"
             onClick={closeSidebar}
@@ -279,7 +317,13 @@ const Dashboard = () => {
             <div className="flex justify-between items-center px-6 py-3">
               {/* Page title */}
               <div className="flex flex-col min-w-0">
-                <h1 className="text-base font-semibold leading-tight truncate">{pageMeta.title}</h1>
+                <h1
+                  ref={pageTitleRef}
+                  tabIndex={-1}
+                  className="text-base font-semibold leading-tight truncate focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  {pageMeta.title}
+                </h1>
                 {pageMeta.subtitle && (
                   <p className="text-xs text-muted-foreground truncate">{pageMeta.subtitle}</p>
                 )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -62,7 +62,10 @@ const Dashboard = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { signOut } = useSupabaseAuth();
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return window.innerWidth >= DESKTOP_BREAKPOINT;
+  });
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
   const pageTitleRef = useRef<HTMLHeadingElement>(null);
   const previousBodyOverflowRef = useRef<string | null>(null);
@@ -175,16 +178,17 @@ const Dashboard = () => {
     const handleResize = () => {
       const desktop = window.innerWidth >= DESKTOP_BREAKPOINT;
       setIsDesktopViewport(desktop);
-      syncBodyScrollLock(sidebarOpen && !desktop);
-      if (desktop) {
-        setSidebarOpen(true);
-      }
+      // Always sync scroll lock on resize — handles mobile→desktop AND desktop→mobile
+      setSidebarOpen((prev) => {
+        syncBodyScrollLock(prev && !desktop);
+        return desktop ? true : prev;
+      });
     };
 
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [sidebarOpen, syncBodyScrollLock]);
+  }, [syncBodyScrollLock]);
 
   // Render the active page content
   const renderContent = () => {
@@ -305,7 +309,7 @@ const Dashboard = () => {
         {!isDesktopViewport && sidebarOpen && (
           <div
             className="fixed inset-0 bg-black/50 z-30 lg:hidden"
-            onClick={closeSidebar}
+            onClick={() => closeSidebar()}
             aria-hidden="true"
           />
         )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -37,7 +37,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 const SIDEBAR_COLLAPSED_KEY = 'maas-sidebar-collapsed';
@@ -62,6 +62,13 @@ const Dashboard = () => {
   const navigate = useNavigate();
   const { signOut } = useSupabaseAuth();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Close mobile drawer and return focus to the toggle button
+  const closeSidebar = () => {
+    setSidebarOpen(false);
+    requestAnimationFrame(() => toggleButtonRef.current?.focus());
+  };
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
@@ -83,23 +90,32 @@ const Dashboard = () => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && sidebarOpen && window.innerWidth < 1024) {
-        setSidebarOpen(false);
+        closeSidebar();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [sidebarOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Move focus into sidebar when drawer opens on mobile
+  useEffect(() => {
+    if (sidebarOpen && window.innerWidth < 1024) {
+      const sidebar = document.getElementById('dashboard-sidebar');
+      const firstFocusable = sidebar?.querySelector<HTMLElement>(
+        'button, [href], input, [tabindex]:not([tabindex="-1"])'
+      );
+      firstFocusable?.focus();
+    }
   }, [sidebarOpen]);
 
   // Body scroll lock while mobile drawer is open
   useEffect(() => {
     const isMobile = window.innerWidth < 1024;
-    if (sidebarOpen && isMobile) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
+    if (!sidebarOpen || !isMobile) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
     return () => {
-      document.body.style.overflow = '';
+      document.body.style.overflow = previousOverflow;
     };
   }, [sidebarOpen]);
 
@@ -211,10 +227,11 @@ const Dashboard = () => {
       <div className="flex h-[calc(100vh-4rem)]">
         {/* Mobile Sidebar Toggle */}
         <Button
+          ref={toggleButtonRef}
           variant="ghost"
           size="icon"
           className="fixed top-20 left-4 z-50 lg:hidden"
-          onClick={() => setSidebarOpen(!sidebarOpen)}
+          onClick={() => sidebarOpen ? closeSidebar() : setSidebarOpen(true)}
           aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
           aria-expanded={sidebarOpen}
           aria-controls="dashboard-sidebar"
@@ -244,7 +261,7 @@ const Dashboard = () => {
         {sidebarOpen && (
           <div
             className="fixed inset-0 bg-black/50 z-30 lg:hidden"
-            onClick={() => setSidebarOpen(false)}
+            onClick={closeSidebar}
             aria-hidden="true"
           />
         )}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -37,8 +37,24 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+
+const SIDEBAR_COLLAPSED_KEY = 'maas-sidebar-collapsed';
+
+const PAGE_META: Record<string, { title: string; subtitle?: string }> = {
+  'overview':          { title: 'Overview' },
+  'api-keys':          { title: 'Router Keys',       subtitle: 'Manage API access keys' },
+  'orchestrator':      { title: 'Orchestrator',      subtitle: 'AI workflow automation' },
+  'ai-tools':          { title: 'AI Tools' },
+  'memory-visualizer': { title: 'Context Explorer' },
+  'memory-analytics':  { title: 'Context Analytics' },
+  'mcp-tracking':      { title: 'Request Tracking' },
+  'scheduler':         { title: 'Scheduler' },
+  'mcp-services':      { title: 'API Services' },
+  'mcp-usage':         { title: 'Usage Analytics' },
+  'extensions':        { title: 'MCP Extensions' },
+};
 
 const Dashboard = () => {
   const { theme, setTheme, resolvedTheme } = useTheme();
@@ -46,6 +62,46 @@ const Dashboard = () => {
   const navigate = useNavigate();
   const { signOut } = useSupabaseAuth();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const handleCollapsedChange = (value: boolean) => {
+    setCollapsed(value);
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(value));
+    } catch (e) {
+      console.warn('Failed to save sidebar collapsed state:', e);
+    }
+  };
+
+  // Escape key closes mobile drawer
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && sidebarOpen && window.innerWidth < 1024) {
+        setSidebarOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [sidebarOpen]);
+
+  // Body scroll lock while mobile drawer is open
+  useEffect(() => {
+    const isMobile = window.innerWidth < 1024;
+    if (sidebarOpen && isMobile) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [sidebarOpen]);
 
   // Determine active page based on route
   const getActivePage = () => {
@@ -69,6 +125,7 @@ const Dashboard = () => {
   };
 
   const activePage = getActivePage();
+  const pageMeta = PAGE_META[activePage] ?? { title: 'Dashboard' };
 
   // Render the active page content
   const renderContent = () => {
@@ -158,17 +215,23 @@ const Dashboard = () => {
           size="icon"
           className="fixed top-20 left-4 z-50 lg:hidden"
           onClick={() => setSidebarOpen(!sidebarOpen)}
+          aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+          aria-expanded={sidebarOpen}
+          aria-controls="dashboard-sidebar"
         >
           {sidebarOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </Button>
 
         {/* Sidebar */}
         <DashboardSidebar
+          id="dashboard-sidebar"
           className={cn(
             "fixed lg:static left-0 top-16 bottom-0 z-40 transform transition-transform duration-200 ease-in-out lg:transform-none",
             "lg:h-auto",
             sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
           )}
+          collapsed={collapsed}
+          onCollapsedChange={handleCollapsedChange}
           onNavigate={() => {
             // Close sidebar on mobile after navigation
             if (window.innerWidth < 1024) {
@@ -182,6 +245,7 @@ const Dashboard = () => {
           <div
             className="fixed inset-0 bg-black/50 z-30 lg:hidden"
             onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
           />
         )}
 
@@ -189,7 +253,15 @@ const Dashboard = () => {
         <main className="flex-1 overflow-auto">
           {/* Top Bar */}
           <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b border-border">
-            <div className="flex justify-end items-center px-6 py-3">
+            <div className="flex justify-between items-center px-6 py-3">
+              {/* Page title */}
+              <div className="flex flex-col min-w-0">
+                <h1 className="text-base font-semibold leading-tight truncate">{pageMeta.title}</h1>
+                {pageMeta.subtitle && (
+                  <p className="text-xs text-muted-foreground truncate">{pageMeta.subtitle}</p>
+                )}
+              </div>
+
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -230,7 +230,7 @@ const Dashboard = () => {
           ref={toggleButtonRef}
           variant="ghost"
           size="icon"
-          className="fixed top-20 left-4 z-50 lg:hidden"
+          className="fixed top-16 left-4 z-50 lg:hidden"
           onClick={() => sidebarOpen ? closeSidebar() : setSidebarOpen(true)}
           aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
           aria-expanded={sidebarOpen}


### PR DESCRIPTION
- Wire collapsed/onCollapsedChange props in Dashboard.tsx (desktop collapse
  was a dead feature — toggle button and Ctrl+B called undefined callback)
- Persist sidebar collapsed preference to localStorage ('maas-sidebar-collapsed')
- Add Escape key handler to close mobile drawer
- Add body scroll lock (overflow:hidden) while mobile drawer is open
- Add aria-label, aria-expanded, aria-controls to mobile sidebar toggle button
- Add aria-hidden to mobile overlay backdrop
- Add dynamic page title + subtitle to top bar (left side, per-route metadata)
- DashboardSidebar: accept id prop, forward to <aside>
- DashboardSidebar: add aria-expanded on section header buttons
- DashboardSidebar: add aria-current="page" on active nav item buttons
- DashboardSidebar: add aria-label on favorite toggle buttons

https://claude.ai/code/session_01YVNyoKaRCKyzKZ98ntVcp5